### PR TITLE
Do not fail if postgres-9.4 does not exist

### DIFF
--- a/jobs/bucc-bbr/templates/post-backup-unlock
+++ b/jobs/bucc-bbr/templates/post-backup-unlock
@@ -4,6 +4,6 @@ set -e
 
 # Director restore needs postgres-9.4 to be inplace
 pushd /var/vcap/packages
-rm postgres-9.4
+rm -rf postgres-9.4
 mv postgres-9.4{back,}
 


### PR DESCRIPTION
It is possible that `bbr backup` failed, and when it tries to cleanup bucc-bbr there is no postgres-9.4 folder. Which causes `rm postgres-9.4` to fail, and the unlocking fails.

/cc @rkoster 